### PR TITLE
kiteconnect/__init__.py: Fix typo in positional argumnet

### DIFF
--- a/kiteconnect/__init__.py
+++ b/kiteconnect/__init__.py
@@ -38,7 +38,7 @@ Getting started
     # Once you have the request_token, obtain the access_token
     # as follows.
 
-    data = kite.generate_session("request_token_here", secret="your_secret")
+    data = kite.generate_session("request_token_here", api_secret="your_secret")
     kite.set_access_token(data["access_token"])
 
     # Place an order


### PR DESCRIPTION
Fixes minor typo (`s/secret/api_secret`) present in the [docs](https://github.com/zerodhatech/pykiteconnect/blob/kite3/kiteconnect/__init__.py#L41)