### PR TITLE
fix: Do not subscribe if there was an unclean closure before

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
-pytest
-responses
-codecov
-pytest-cov
-flake8
-mock
+pytest==4.1.1
+responses==0.10.5
+codecov==2.0.15
+pytest-cov==2.6.1
+flake8==3.6.0
+mock==2.0.0


### PR DESCRIPTION
This is an ugly hack to prevent resubscription if there was an unclean closure before. What if the connection is a new one / server removes the connection?