### PR TITLE
fix: Use setuptools egg install runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ class install(_install):
             # Install from Pypi for other platforms
             pip_install("Twisted>=17.9.0")
 
-        _install.do_egg_install(self)
+        _install.run(self)
 
 
 class FakeBdist(Command):


### PR DESCRIPTION
* https://github.com/pypa/pip/issues/6998
Do not assume egg install for all setuptools version