### PR TITLE
fix: corrected kite.trade url in documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1056,7 +1056,7 @@ table {
 
   <header id="section-intro">
   <h1 class="title"><span class="name">kiteconnect</span> module</h1>
-  <p>Kite Connect API client for Python -- <a href="kite.trade">https://kite.trade</a>.</p>
+  <p>Kite Connect API client for Python -- <a href="https://kite.trade">kite.trade</a>.</p>
 <p>Zerodha technologies (c) 2018</p>
 <h2>License</h2>
 <p>KiteConnect Python library is licensed under the MIT License</p>


### PR DESCRIPTION
The href url of an a tag in the documentation was not redirecting to the correct url, but was redirecting relatively which has been fixed.